### PR TITLE
global context, reducer, delete cart item

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import { BrowserRouter as Router, Route } from "react-router-dom";
 import Header from "Header/Header";
 import ShoppingCartPage from "./ShoppingCartPage/ShoppingCartPage";
 import { useState } from "react";
+import { GlobalProvider } from './context/GlobalState';
 
 function App() {
   const [headerTitle, setHeaderTitle] = useState("Gėlių e-parduotuvė");
@@ -12,24 +13,26 @@ function App() {
     setHeaderTitle(title);
   };
   return (
-    <Router>
-      <div className="App">
-        <Header title={headerTitle} />
+    <GlobalProvider>
+      <Router>
+        <div className="App">
+          <Header title={headerTitle} />
 
-        <Route
-          exact
-          path="/"
-          component={() => <FrontPage updateHeaderTitle={updateHeaderTitle} />}
-        />
-        <Route
-          exact
-          path="/cart"
-          component={() => (
-            <ShoppingCartPage updateHeaderTitle={updateHeaderTitle} />
-          )}
-        />
-      </div>
-    </Router>
+          <Route
+            exact
+            path="/"
+            component={() => <FrontPage updateHeaderTitle={updateHeaderTitle} />}
+          />
+          <Route
+            exact
+            path="/cart"
+            component={() => (
+              <ShoppingCartPage updateHeaderTitle={updateHeaderTitle} />
+            )}
+          />
+        </div>
+      </Router>
+    </GlobalProvider>
   );
 }
 

--- a/src/ShoppingCartPage/ShoppingCartRow.js
+++ b/src/ShoppingCartPage/ShoppingCartRow.js
@@ -1,11 +1,11 @@
-import React, { useState } from "react";
+import React, { useState, useContext } from "react";
 import { MdClear } from "react-icons/md";
 import Button from "react-bootstrap/Button";
+import { GlobalContext } from '../context/GlobalState.js';
 
 const ShoppingCartRow = ({ item }) => {
   const [amount, setAmount] = useState(item.amount);
-
-  const deleteFromCart = () => {};
+  const { deleteItem } = useContext(GlobalContext);
 
   const onAmountChange = (e) => {
     let inputAmount = e.target.value;
@@ -36,7 +36,7 @@ const ShoppingCartRow = ({ item }) => {
         <Button
           type="button"
           variant="delete"
-          onClick={() => deleteFromCart(item.id)}
+          onClick={() => deleteItem(item.id)}
         >
           <MdClear size={20} />
         </Button>

--- a/src/ShoppingCartPage/ShoppingCartTable.js
+++ b/src/ShoppingCartPage/ShoppingCartTable.js
@@ -1,9 +1,11 @@
-import React, { useState } from "react";
+import React, { useContext } from "react";
 import Table from "react-bootstrap/Table";
 import ShoppingCartRow from "./ShoppingCartRow";
-import tempMockItems from "./TempMockItems";
+import { GlobalContext } from '../context/GlobalState.js';
 
 const ShoppingCartTable = () => {
+  const { cartItems } = useContext(GlobalContext);
+
   return (
     <Table bordered hover className="shopping-cart-table">
       <thead>
@@ -17,7 +19,7 @@ const ShoppingCartTable = () => {
         </tr>
       </thead>
       <tbody>
-        {tempMockItems.map((item) => (
+        {cartItems.map((item) => (
           <ShoppingCartRow item={item} key={item.id} />
         ))}
       </tbody>

--- a/src/context/AppReducer.js
+++ b/src/context/AppReducer.js
@@ -1,0 +1,13 @@
+function AppReducer (state, action) {
+    switch (action.type) {
+    case 'DELETE_ITEM':
+        return {
+            ...state,
+            cartItems: state.cartItems.filter((item) => item.id !== action.payload),
+        };
+    default:
+        return state;
+    }
+  };
+
+  export default AppReducer;

--- a/src/context/GlobalState.js
+++ b/src/context/GlobalState.js
@@ -1,0 +1,43 @@
+import React, { createContext, useReducer } from 'react';
+import AppReducer from './AppReducer';
+
+const initialState = {
+  cartItems: [ { id: 1, image: 'https://images.unsplash.com/photo-1554631221-f9603e6808be?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=334&q=80',
+    title: 'Kaktusas', price: 5.99, amount: 4 },
+    { id: 2, image: 'https://www.ikea.com/gb/en/images/products/smycka-artificial-flower-rose-red__0636963_pe698124_s5.jpg', title: 'Rožės', price: 25.50, amount: 2 },
+    { id: 3, image: 'https://i.pinimg.com/564x/18/4b/61/184b61bfe08b19ee4f4e07d605673d6f.jpg', title: 'Prabangi puokste', price: 100, amount: 1 },
+    ]
+};
+
+export const GlobalContext = createContext(initialState);
+
+export const GlobalProvider = ({ children }) => {
+  const [state, dispatch] = useReducer(AppReducer, initialState);
+
+    function deleteItem(id) {
+      try {
+        // await axios.delete(`/api/cartIems/${id}`);
+          dispatch({
+            type: 'DELETE_ITEM',
+            payload: id,
+        });
+      }
+       catch (error) {
+        // dispatch({
+        //   type: 'ITEM_DELETE_ERROR',
+        //   payload: error.response.data.error,
+        // });
+       }
+    }
+
+  return (
+    <GlobalContext.Provider
+      value={{
+        cartItems: state.cartItems,
+        deleteItem
+      }}  
+    >
+      {children}
+    </GlobalContext.Provider>
+  );
+};  

--- a/src/context/GlobalState.js
+++ b/src/context/GlobalState.js
@@ -16,17 +16,12 @@ export const GlobalProvider = ({ children }) => {
 
     function deleteItem(id) {
       try {
-        // await axios.delete(`/api/cartIems/${id}`);
           dispatch({
             type: 'DELETE_ITEM',
             payload: id,
         });
       }
        catch (error) {
-        // dispatch({
-        //   type: 'ITEM_DELETE_ERROR',
-        //   payload: error.response.data.error,
-        // });
        }
     }
 


### PR DESCRIPTION
Dabar kaip yra: gali ištrinti iš shopping cart, bet po refresho vėl atsiras

<strike>Idėja tokia: paspaudus pridėti į cart mygtuką - bus kviečiamas endpointas kad persistint į db. Taip pat ir paspaudus delete bus kviečimas endpointas deletint tą itemą. Į state užloadins iš db kai tik atsidarysim cart page `  const res = await axios.get('/api/cartItems');
      dispatch({
        type: 'GET_ITEMS',
        payload: res.data.data,
      });`

atrodo taip bus mažiau galvos skausmo frontenderiams negu saugoti į visokius local storage :D </strike>